### PR TITLE
Support enclosures in feed items

### DIFF
--- a/src/JdlBot/Feed.pm
+++ b/src/JdlBot/Feed.pm
@@ -122,11 +122,16 @@ sub scrape {
 								next;
 							}
 						}
+						my $enclosures = [];
+						foreach my $enc ( $item->get('enclosure@url') ) {
+							push(@$enclosures, $enc);
+						}
 						push(
 							@{ $filters->{$filter}->{'matches'} },
 							{
 								'title'       => $item->title(),
 								'content'     => $item->description() . " " . $item->link(),
+								'enclosures'  => $enclosures,
 								'new_tv_last' => $episodeID
 							}
 						);
@@ -237,6 +242,11 @@ CONTENT: foreach my $count ( 0 .. $#{ $filter->{'matches'} } ) {
 			}
 		);
 		$finder->find( \$filter->{'matches'}->[$count]->{'content'} );
+
+		# handle enclosures
+		if ( $filter->{'matches'}->[$count]->{'enclosures'} ) {
+			push(@links, @{$filter->{'matches'}->[$count]->{'enclosures'}});
+		}
 
 		my $prevLink;
 		my $linksToProcess = [];


### PR DESCRIPTION
RSS can use Enclosure element to directly link to some content, downloads etc,
see i.e. https://www.w3schools.com/xml/rss_tag_enclosure.asp for details.

This commit tries to add all links from enclosures to links we are matching our
filters against.

**My Perl skills are super rusty** so if you choose to include this, please feel free to rewrite it. My goal was only to get it working :) 